### PR TITLE
Updated benchmark to use pooling

### DIFF
--- a/src/AsyncKeyLock.Benchmarks/BenchmarkSimpleKeyLock.cs
+++ b/src/AsyncKeyLock.Benchmarks/BenchmarkSimpleKeyLock.cs
@@ -1,5 +1,4 @@
 ﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 
 namespace AsyncKeyLock.Benchmarks;
 
@@ -10,7 +9,10 @@ public class BenchmarkSimpleKeyLock
     public void GlobalSetup()
     {
         _AsyncKeyLock = new AsyncLock<string>();
-        _AsyncKeyedLock = new AsyncKeyedLock.AsyncKeyedLocker<string>();
+        _AsyncKeyedLock = new AsyncKeyedLock.AsyncKeyedLocker<string>(o =>
+        {
+            o.PoolSize = NumberOfLocks;
+        });
         _ImageSharpWebLock = new SixLabors.ImageSharp.Web.Synchronization.AsyncKeyLock<string>();
     }
 


### PR DESCRIPTION
The way you are benchmarking currently doesn't cater for multi-threading or contention. I didn't want to change such tests; however, I did amend the benchmark for my library to use the pooling (which by default is disabled) and you will be able to notice the big difference in the memory allocations.